### PR TITLE
add more delay for write and control flow

### DIFF
--- a/RS485/RS485.cpp
+++ b/RS485/RS485.cpp
@@ -24,7 +24,7 @@ RS485::RS485(const uint8_t board_address, const uint32_t prefered_sleep_time, co
     te = new DigitalOut(RS485_TE_PIN, te_value);
     de = new DigitalOut(RS485_DE_PIN, 0);
 
-
+    rs485->set_flow_control(Disabled);
     this->board_adress = board_address;
     this->prefered_sleep_time = prefered_sleep_time;
     this->packet_array_size = packet_array_size;
@@ -134,7 +134,7 @@ void RS485::write(const uint8_t slave, const uint8_t cmd, const uint8_t nb_byte,
     serial_write((uint8_t)(checksum >> 8));
     serial_write((uint8_t)(checksum & 0xFF));
     serial_write(0x0D);
-    ThisThread::sleep_for(10);
+    ThisThread::sleep_for(20);
     de->write(0);
     writer_mutex.unlock();
 }

--- a/RS485/RS485.cpp
+++ b/RS485/RS485.cpp
@@ -24,7 +24,7 @@ RS485::RS485(const uint8_t board_address, const uint32_t prefered_sleep_time, co
     te = new DigitalOut(RS485_TE_PIN, te_value);
     de = new DigitalOut(RS485_DE_PIN, 0);
 
-    rs485->set_flow_control(Disabled);
+    rs485->set_flow_control(Disabled, NC, NC);
     this->board_adress = board_address;
     this->prefered_sleep_time = prefered_sleep_time;
     this->packet_array_size = packet_array_size;

--- a/RS485/RS485.cpp
+++ b/RS485/RS485.cpp
@@ -24,7 +24,7 @@ RS485::RS485(const uint8_t board_address, const uint32_t prefered_sleep_time, co
     te = new DigitalOut(RS485_TE_PIN, te_value);
     de = new DigitalOut(RS485_DE_PIN, 0);
 
-    rs485->set_flow_control(Disabled, NC, NC);
+    rs485->set_flow_control(mbed::SerialBase::Disabled, NC, NC);
     this->board_adress = board_address;
     this->prefered_sleep_time = prefered_sleep_time;
     this->packet_array_size = packet_array_size;


### PR DESCRIPTION
**Warning :** Before creating a pull request, make sure that it does not already exists in the [pull requests](../). Thank you.

## Description
Add delay in the write of RS485 to get a better message reception. Set the control flow for the RawSerial

## How has this been tested ?
Been tested on power management for more than 1 hour without crashing or blocking the rs485 bus.

## Checklist
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings